### PR TITLE
Fix typo with expiry_month

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -140,7 +140,7 @@ class Transaction
         }
 
         if (isset($params['expiry_month']) && isset($params['expiry_year']) && !isset($params['expdate'])) {
-            $params['expdate'] = sprintf('%02%02d', $params['expiry_year'], $params['expiry_monthp']);
+            $params['expdate'] = sprintf('%02%02d', $params['expiry_year'], $params['expiry_month']);
             unset($params['expiry_year'], $params['expiry_month']);
         }
 

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -140,7 +140,7 @@ class Transaction
         }
 
         if (isset($params['expiry_month']) && isset($params['expiry_year']) && !isset($params['expdate'])) {
-            $params['expdate'] = sprintf('%02%02d', $params['expiry_year'], $params['expiry_month']);
+            $params['expdate'] = sprintf('%02d%02d', $params['expiry_year'], $params['expiry_month']);
             unset($params['expiry_year'], $params['expiry_month']);
         }
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -70,7 +70,7 @@ class TransactionTest extends TestCase
 
         $transaction = new Transaction($this->gateway, $params);
 
-        $this->assertEquals('2012', $this->transaction->params['expdate']);
+        $this->assertEquals('2012', $transaction->params['expdate']);
     }
 
     /** @test */

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -59,6 +59,21 @@ class TransactionTest extends TestCase
     }
 
     /** @test */
+    public function it_converts_month_year_to_expdate()
+    {
+        $params = array_merge($this->params, [
+            'expiry_month' => '12',
+            'expiry_year' => '20'
+        ]);
+
+        unset($params['expdate']);
+
+        $transaction = new Transaction($this->gateway, $params);
+
+        $this->assertEquals('2012', $this->transaction->params['expdate']);
+    }
+
+    /** @test */
     public function it_can_prepare_parameters_that_were_submitted_improperly()
     {
         $order = '   1234-567890';


### PR DESCRIPTION
Fixed typo with expiry month / year conversion to expdate, added test case.