### PR TITLE
Status code edge cases.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -134,7 +134,7 @@ class Response
         $gateway = $this->transaction->gateway;
 
         if ($receipt->read('id') === 'Global Error Receipt') {
-            $this->status = Response::GLOBAL_ERROR_RECEIPT;
+            $this->status = self::GLOBAL_ERROR_RECEIPT;
             $this->successful = false;
 
             return $this;
@@ -155,7 +155,7 @@ class Response
             switch ($code) {
                 case 'B':
                 case 'C':
-                    $this->status = Response::AVS_POSTAL_CODE;
+                    $this->status = self::AVS_POSTAL_CODE;
                     break;
                 case 'G':
                 case 'I':
@@ -163,16 +163,16 @@ class Response
                 case 'S':
                 case 'U':
                 case 'Z':
-                    $this->status = Response::AVS_ADDRESS;
+                    $this->status = self::AVS_ADDRESS;
                     break;
                 case 'N':
-                    $this->status = Response::AVS_NO_MATCH;
+                    $this->status = self::AVS_NO_MATCH;
                     break;
                 case 'R':
-                    $this->status = Response::AVS_TIMEOUT;
+                    $this->status = self::AVS_TIMEOUT;
                     break;
                 default:
-                    $this->status = Response::AVS;
+                    $this->status = self::AVS;
             }
 
             $this->failedAvs = true;
@@ -184,7 +184,7 @@ class Response
         $code = !is_null($receipt->read('cvd_result')) ? $receipt->read('cvd_result') : null;
 
         if ($gateway->avs && !is_null($code) && $code !== 'null' && !in_array($code{1}, $gateway->cvdCodes)) {
-            $this->status = Response::CVD;
+            $this->status = self::CVD;
             $this->failedCvd = true;
             $this->successful = false;
 
@@ -206,20 +206,20 @@ class Response
                 case '050':
                 case '074':
                 case 'null':
-                    $status = Response::SYSTEM_UNAVAILABLE;
+                    $status = self::SYSTEM_UNAVAILABLE;
                     break;
                 case '051':
                 case '482':
                 case '484':
-                    $status = Response::CARD_EXPIRED;
+                    $status = self::CARD_EXPIRED;
                     break;
                 case '075':
-                    $status = Response::INVALID_CARD;
+                    $status = self::INVALID_CARD;
                     break;
 
                 case '208':
                 case '475':
-                    $status = Response::INVALID_EXPIRY_DATE;
+                    $status = self::INVALID_EXPIRY_DATE;
                     break;
 
                 case '076':
@@ -228,29 +228,29 @@ class Response
                 case '081':
                 case '082':
                 case '083':
-                    $status = Response::INSUFFICIENT_FUNDS;
+                    $status = self::INSUFFICIENT_FUNDS;
                     break;
                 case '077':
-                    $status = Response::PREAUTH_FULL;
+                    $status = self::PREAUTH_FULL;
                     break;
                 case '078':
-                    $status = Response::DUPLICATE_TRANSACTION;
+                    $status = self::DUPLICATE_TRANSACTION;
                     break;
                 case '481':
                 case '483':
-                    $status = Response::DECLINED;
+                    $status = self::DECLINED;
                     break;
                 case '485':
-                    $status = Response::NOT_AUTHORIZED;
+                    $status = self::NOT_AUTHORIZED;
                     break;
                 case '486':
                 case '487':
                 case '489':
                 case '490':
-                    $status = Response::CVD;
+                    $status = self::CVD;
                     break;
                 default:
-                    $status = Response::ERROR;
+                    $status = self::ERROR;
             }
         }
 
@@ -262,9 +262,9 @@ class Response
         $status = null;
 
         if (preg_match('/invalid pan/i', $message)) {
-            $status = Response::INVALID_CARD;
+            $status = self::INVALID_CARD;
         } else if (preg_match('/invalid expiry date/i', $message)) {
-            $status = Response::INVALID_EXPIRY_DATE;
+            $status = self::INVALID_EXPIRY_DATE;
         }
 
         return $status;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -114,4 +114,36 @@ class ResponseTest extends TestCase
         $this->assertEquals($this->params['order_id'], $receipt->read('id'));
         $this->assertObjectHasAttribute('data', $receipt);
     }
+
+    /** @test */
+    public function it_processes_expdate_error_edge_cases_from_message()
+    {
+        $response = $this->process_transaction([
+            'expdate' => 'foo'
+        ]);
+
+        $this->assertFalse($response->successful);
+        $this->assertEquals(Response::INVALID_EXPIRY_DATE, $response->status);
+    }
+
+    /** @test */
+    public function it_processes_credit_card_error_edge_cases_from_message()
+    {
+        $response = $this->process_transaction([
+            'credit_card' => '1234'
+        ]);
+
+        $this->assertFalse($response->successful);
+        $this->assertEquals(Response::INVALID_CARD, $response->status);
+    }
+
+    protected function process_transaction($extra_params = []) {
+        $this->params = array_merge($this->params, $extra_params);
+        $this->transaction = new Transaction($this->gateway, $this->params);
+
+        $response = $this->processor->process($this->transaction);
+        $response = $response->validate();
+
+        return $response;
+    }
 }


### PR DESCRIPTION
Theres a few edge cases where moneris will return a null code and only a message for things such as invalid pan or invalid expiry date. 

I ported over some logic were using in [ActiveMerchant for ruby/rails](https://github.com/industrialdev/active_merchant/blob/a6dc3de48e0174d15a4526d867f0d87a05ec3319/lib/active_merchant/billing/gateways/moneris.rb#L389-L400) which handles mapping the messages to common error codes. Also added an error code for invalid expiry date.