### PR TITLE
Response success logic

### DIFF
--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -39,6 +39,14 @@ class Receipt
         ]);
     }
 
+    public function successful() {
+        $complete = $this->read('complete');
+        $valid_code = $this->read('code') !== 'null';
+        $code = (int)$this->read('code');
+
+        return $complete && $valid_code && $code >= 0 && $code < 50;
+    }
+
     /**
      * Read an item from the receipt.
      *

--- a/src/Response.php
+++ b/src/Response.php
@@ -140,12 +140,10 @@ class Response
             return $this;
         }
 
-        $code = (int)$receipt->read('code');
+        $this->successful = $receipt->successful();
 
-        if ($code >= 50 || $code === 0) {
+        if (!$this->successful) {
             $this->status = $this->convertReceiptCodeToStatus($receipt);
-            $this->successful = false;
-
             return $this;
         }
 
@@ -176,22 +174,18 @@ class Response
             }
 
             $this->failedAvs = true;
-            $this->successful = false;
 
             return $this;
         }
 
         $code = !is_null($receipt->read('cvd_result')) ? $receipt->read('cvd_result') : null;
 
-        if ($gateway->avs && !is_null($code) && $code !== 'null' && !in_array($code{1}, $gateway->cvdCodes)) {
+        if ($gateway->cvd && !is_null($code) && $code !== 'null' && !in_array($code{1}, $gateway->cvdCodes)) {
             $this->status = self::CVD;
             $this->failedCvd = true;
-            $this->successful = false;
 
             return $this;
         }
-
-        $this->successful = true;
 
         return $this;
     }


### PR DESCRIPTION
As we were discussing previously failed CVD / AVS response doesnt necessarily mean the transaction has failed. After fighting with the moneris API more and reviewing some other libraries I believe their might be a bug with the logic for a successful response.

This PR updates the successful flag to only check if the receipt was complete + if the response code is in the range from [0-49 (Financial Response Codes)](https://developer.moneris.com/More/Testing/Financial%20Response%20Codes).

The failed AVS + CVD flags are still being set but its up to the merchant to decide how they want to handle these (eg. void purchase in application code, manual process etc).

Some other examples of response handling out in the wild:

- [ActiveMerchant (ruby)](https://github.com/activemerchant/active_merchant/blob/4d858af4c9a8a6fca8a6b27cf0e15005c3bd62b2/lib/active_merchant/billing/gateways/moneris.rb#L243-L247)
- [Aktive-Merchant (php)](https://github.com/akDeveloper/Aktive-Merchant/blob/1182ddaa0070f4fe7abea8a5fe66e1716ba4706f/lib/AktiveMerchant/Billing/Gateways/Moneris.php#L435)
- [Botnary/moneris-api (php)](https://github.com/Botnary/moneris-api/blob/cb1649325fe38050ec33f0cd38f7c2ec33d804e2/src/Zone/PaymentGateway/Integration/Moneris.php#L77)

I was hoping to add some more functional test for Response but the moneris test APIs like to return odd result later in the day. Will try again in the morning and see what gets returned for the [Penny values](https://developer.moneris.com/More/Testing/Penny%20Value%20Simulator).